### PR TITLE
fix: unescape attr slashes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,22 +71,22 @@ const fixupAttr = astNode => {
       matcher.insensitive = true
     }
   } else {
-    matcher.qualifiedAttribute = attributeAstNode.qualifiedAttribute
-    matcher.operator = attributeAstNode.operator || ''
-    matcher.value = attributeAstNode.value
-
-    // backwards compatibility
-    matcher.attribute = attributeAstNode.qualifiedAttribute
-
-    if (attributeAstNode.insensitive) {
-      matcher.insensitive = true
-    }
-
     if (attributeAstNode.type !== 'attribute') {
       throw Object.assign(
         new Error('`:attr` pseudo-class expects an attribute matcher as the last value'),
         { code: 'EQUERYATTR' }
       )
+    }
+
+    matcher.qualifiedAttribute = unescapeSlashes(attributeAstNode.qualifiedAttribute)
+    matcher.operator = attributeAstNode.operator
+    matcher.value = attributeAstNode.value
+
+    // backwards compatibility
+    matcher.attribute = matcher.qualifiedAttribute
+
+    if (attributeAstNode.insensitive) {
+      matcher.insensitive = true
     }
   }
 

--- a/tap-snapshots/test/index.js.test.cjs
+++ b/tap-snapshots/test/index.js.test.cjs
@@ -5804,6 +5804,83 @@ exports[`test/index.js TAP > :attr(dependencies, [bar="^1.0.0"]) 1`] = `
 }
 `
 
+exports[`test/index.js TAP > :attr(devDependencies, [@scoped/package]) 1`] = `
+&ref_2 Root {
+  "_error": Function (message, errorOptions),
+  "indexes": Object {},
+  "lastEach": 1,
+  "nodes": Array [
+    &ref_1 Selector {
+      "indexes": Object {},
+      "lastEach": 1,
+      "nodes": Array [
+        Pseudo {
+          "attributeMatcher": Object {
+            "attribute": "@scoped/package",
+            "operator": undefined,
+            "qualifiedAttribute": "@scoped/package",
+            "value": undefined,
+          },
+          "lookupProperties": Array [
+            "devDependencies",
+          ],
+          "nodes": Array [],
+          "parent": <*ref_1>,
+          "source": Object {
+            "end": Object {
+              "column": 42,
+              "line": 1,
+            },
+            "start": Object {
+              "column": 1,
+              "line": 1,
+            },
+          },
+          "sourceIndex": 0,
+          "spaces": Object {
+            "after": "",
+            "before": "",
+          },
+          "type": "pseudo",
+          "value": ":attr",
+        },
+      ],
+      "parent": <*ref_2>,
+      "source": Object {
+        "end": Object {
+          "column": 42,
+          "line": 1,
+        },
+        "start": Object {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "spaces": Object {
+        "after": "",
+        "before": "",
+      },
+      "type": "selector",
+    },
+  ],
+  "source": Object {
+    "end": Object {
+      "column": 42,
+      "line": 1,
+    },
+    "start": Object {
+      "column": 1,
+      "line": 1,
+    },
+  },
+  "spaces": Object {
+    "after": "",
+    "before": "",
+  },
+  "type": "root",
+}
+`
+
 exports[`test/index.js TAP > :attr(funding, :attr([type=GitHub i])) 1`] = `
 &ref_2 Root {
   "_error": Function (message, errorOptions),

--- a/test/index.js
+++ b/test/index.js
@@ -92,6 +92,7 @@ const checks = [
   [':attr([name=dasher i])'],
   [':attr(dependencies, [bar="^1.0.0"])'],
   [':attr(dependencies, :attr([bar="^1.0.0"]))'],
+  [':attr(devDependencies, [@scoped/package])'],
   [':attr([keywords=lorem])'],
   [':attr(arbitrary, [foo$=oo])'],
   [':attr(arbitrary, [foo*=oo])'],


### PR DESCRIPTION
This allows us to do things like `:attr(dependencies, [@scoped/package])`
