### PR TITLE
remove version parsing from #name selector, remove `npm-package-arg`, remove `semver`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const npa = require('npm-package-arg')
 const parser = require('postcss-selector-parser')
 const semver = require('semver')
 
@@ -11,37 +10,6 @@ const escapeSlashes = str =>
 
 const unescapeSlashes = str =>
   str.replace(/\\\//g, '/')
-
-const fixupIds = astNode => {
-  const { name, rawSpec: part } = npa(astNode.value)
-  const versionParts = [{ astNode, part }]
-  let currentAstNode = astNode.next()
-
-  if (!part) {
-    return
-  }
-
-  while (currentAstNode) {
-    versionParts.push({ astNode: currentAstNode, part: String(currentAstNode) })
-    currentAstNode = currentAstNode.next()
-  }
-
-  let version
-  let length = versionParts.length
-  while (!version && length) {
-    version =
-      semver.valid(
-        versionParts.slice(0, length).reduce((res, i) => `${res}${i.part}`, '')
-      )
-    length--
-  }
-
-  astNode.value = `${name}@${version}`
-
-  for (let i = 1; i <= length; i++) {
-    versionParts[i].astNode.remove()
-  }
-}
 
 // recursively fixes up any :attr pseudo-class found
 const fixupAttr = astNode => {
@@ -186,10 +154,6 @@ const fixupOutdated = astNode => {
 // of the parsed ast from the query and modifying the parsed nodes accordingly
 const transformAst = selector => {
   selector.walk((nextAstNode) => {
-    if (nextAstNode.type === 'id') {
-      fixupIds(nextAstNode)
-    }
-
     switch (nextAstNode.value) {
       case ':attr':
         return fixupAttr(nextAstNode)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const parser = require('postcss-selector-parser')
-const semver = require('semver')
 
 const arrayDelimiter = Symbol('arrayDelimiter')
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "tap": "^16.2.0"
   },
   "dependencies": {
-    "npm-package-arg": "^9.1.0",
     "postcss-selector-parser": "^6.0.10",
     "semver": "^7.3.7"
   },

--- a/package.json
+++ b/package.json
@@ -47,8 +47,7 @@
     "tap": "^16.2.0"
   },
   "dependencies": {
-    "postcss-selector-parser": "^6.0.10",
-    "semver": "^7.3.7"
+    "postcss-selector-parser": "^6.0.10"
   },
   "repository": {
     "type": "git",

--- a/tap-snapshots/test/index.js.test.cjs
+++ b/tap-snapshots/test/index.js.test.cjs
@@ -5,76 +5,6 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/index.js TAP > #@npmcli/abbrev@2.0.0-beta.45 1`] = `
-&ref_2 Root {
-  "_error": Function (message, errorOptions),
-  "indexes": Object {},
-  "lastEach": 1,
-  "nodes": Array [
-    &ref_1 Selector {
-      "indexes": Object {},
-      "lastEach": 1,
-      "nodes": Array [
-        ID {
-          "parent": <*ref_1>,
-          "raws": Object {
-            "value": "@npmcli\\\\/abbrev@2",
-          },
-          "source": Object {
-            "end": Object {
-              "column": 18,
-              "line": 1,
-            },
-            "start": Object {
-              "column": 1,
-              "line": 1,
-            },
-          },
-          "sourceIndex": 0,
-          "spaces": Object {
-            "after": "",
-            "before": "",
-          },
-          "type": "id",
-          "value": "@npmcli/abbrev@2.0.0-beta.45",
-        },
-      ],
-      "parent": <*ref_2>,
-      "source": Object {
-        "end": Object {
-          "column": 30,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "spaces": Object {
-        "after": "",
-        "before": "",
-      },
-      "type": "selector",
-    },
-  ],
-  "source": Object {
-    "end": Object {
-      "column": 30,
-      "line": 1,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-    },
-  },
-  "spaces": Object {
-    "after": "",
-    "before": "",
-  },
-  "type": "root",
-}
-`
-
 exports[`test/index.js TAP > #a *:root 1`] = `
 &ref_2 Root {
   "_error": Function (message, errorOptions),
@@ -433,7 +363,7 @@ exports[`test/index.js TAP > #a ~ :root 1`] = `
 }
 `
 
-exports[`test/index.js TAP > #a, #bar:semver(2), #foo@2.2.2 1`] = `
+exports[`test/index.js TAP > #a, #bar:semver(2), #foo 1`] = `
 &ref_2 Root {
   "_error": Function (message, errorOptions),
   "indexes": Object {},
@@ -560,7 +490,7 @@ exports[`test/index.js TAP > #a, #bar:semver(2), #foo@2.2.2 1`] = `
           "parent": <*ref_4>,
           "source": Object {
             "end": Object {
-              "column": 26,
+              "column": 24,
               "line": 1,
             },
             "start": Object {
@@ -574,13 +504,13 @@ exports[`test/index.js TAP > #a, #bar:semver(2), #foo@2.2.2 1`] = `
             "before": "",
           },
           "type": "id",
-          "value": "foo@2.2.2",
+          "value": "foo",
         },
       ],
       "parent": <*ref_2>,
       "source": Object {
         "end": Object {
-          "column": 30,
+          "column": 24,
           "line": 1,
         },
         "start": Object {
@@ -597,7 +527,7 @@ exports[`test/index.js TAP > #a, #bar:semver(2), #foo@2.2.2 1`] = `
   ],
   "source": Object {
     "end": Object {
-      "column": 30,
+      "column": 24,
       "line": 1,
     },
     "start": Object {
@@ -2858,73 +2788,6 @@ exports[`test/index.js TAP > #bar:semver(~2.0.0) 1`] = `
 }
 `
 
-exports[`test/index.js TAP > #bar@2.0.0 1`] = `
-&ref_2 Root {
-  "_error": Function (message, errorOptions),
-  "indexes": Object {},
-  "lastEach": 1,
-  "nodes": Array [
-    &ref_1 Selector {
-      "indexes": Object {},
-      "lastEach": 1,
-      "nodes": Array [
-        ID {
-          "parent": <*ref_1>,
-          "source": Object {
-            "end": Object {
-              "column": 6,
-              "line": 1,
-            },
-            "start": Object {
-              "column": 1,
-              "line": 1,
-            },
-          },
-          "sourceIndex": 0,
-          "spaces": Object {
-            "after": "",
-            "before": "",
-          },
-          "type": "id",
-          "value": "bar@2.0.0",
-        },
-      ],
-      "parent": <*ref_2>,
-      "source": Object {
-        "end": Object {
-          "column": 10,
-          "line": 1,
-        },
-        "start": Object {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "spaces": Object {
-        "after": "",
-        "before": "",
-      },
-      "type": "selector",
-    },
-  ],
-  "source": Object {
-    "end": Object {
-      "column": 10,
-      "line": 1,
-    },
-    "start": Object {
-      "column": 1,
-      "line": 1,
-    },
-  },
-  "spaces": Object {
-    "after": "",
-    "before": "",
-  },
-  "type": "root",
-}
-`
-
 exports[`test/index.js TAP > #ipsum 1`] = `
 &ref_2 Root {
   "_error": Function (message, errorOptions),
@@ -3396,7 +3259,7 @@ exports[`test/index.js TAP > * > :root 1`] = `
 }
 `
 
-exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
+exports[`test/index.js TAP > *:has(* > #bar) 1`] = `
 &ref_4 Root {
   "_error": Function (message, errorOptions),
   "indexes": Object {},
@@ -3484,7 +3347,7 @@ exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
                     "parent": <*ref_2>,
                     "source": Object {
                       "end": Object {
-                        "column": 16,
+                        "column": 14,
                         "line": 1,
                       },
                       "start": Object {
@@ -3498,13 +3361,13 @@ exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
                       "before": "",
                     },
                     "type": "id",
-                    "value": "bar@1.4.0",
+                    "value": "bar",
                   },
                 ],
                 "parent": <*ref_3>,
                 "source": Object {
                   "end": Object {
-                    "column": 21,
+                    "column": 15,
                     "line": 1,
                   },
                   "start": Object {
@@ -3529,7 +3392,7 @@ exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
           "parent": <*ref_1>,
           "source": Object {
             "end": Object {
-              "column": 21,
+              "column": 15,
               "line": 1,
             },
             "start": Object {
@@ -3549,7 +3412,7 @@ exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
       "parent": <*ref_4>,
       "source": Object {
         "end": Object {
-          "column": 21,
+          "column": 15,
           "line": 1,
         },
         "start": Object {
@@ -3566,7 +3429,7 @@ exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
   ],
   "source": Object {
     "end": Object {
-      "column": 21,
+      "column": 15,
       "line": 1,
     },
     "start": Object {
@@ -3582,7 +3445,7 @@ exports[`test/index.js TAP > *:has(* > #bar@1.4.0) 1`] = `
 }
 `
 
-exports[`test/index.js TAP > *:has(> #bar@1.4.0) 1`] = `
+exports[`test/index.js TAP > *:has(> #bar) 1`] = `
 &ref_4 Root {
   "_error": Function (message, errorOptions),
   "indexes": Object {},
@@ -3645,7 +3508,7 @@ exports[`test/index.js TAP > *:has(> #bar@1.4.0) 1`] = `
                     "parent": <*ref_2>,
                     "source": Object {
                       "end": Object {
-                        "column": 14,
+                        "column": 12,
                         "line": 1,
                       },
                       "start": Object {
@@ -3659,13 +3522,13 @@ exports[`test/index.js TAP > *:has(> #bar@1.4.0) 1`] = `
                       "before": "",
                     },
                     "type": "id",
-                    "value": "bar@1.4.0",
+                    "value": "bar",
                   },
                 ],
                 "parent": <*ref_3>,
                 "source": Object {
                   "end": Object {
-                    "column": 19,
+                    "column": 13,
                     "line": 1,
                   },
                   "start": Object {
@@ -3690,7 +3553,7 @@ exports[`test/index.js TAP > *:has(> #bar@1.4.0) 1`] = `
           "parent": <*ref_1>,
           "source": Object {
             "end": Object {
-              "column": 19,
+              "column": 13,
               "line": 1,
             },
             "start": Object {
@@ -3710,7 +3573,7 @@ exports[`test/index.js TAP > *:has(> #bar@1.4.0) 1`] = `
       "parent": <*ref_4>,
       "source": Object {
         "end": Object {
-          "column": 19,
+          "column": 13,
           "line": 1,
         },
         "start": Object {
@@ -3727,7 +3590,7 @@ exports[`test/index.js TAP > *:has(> #bar@1.4.0) 1`] = `
   ],
   "source": Object {
     "end": Object {
-      "column": 19,
+      "column": 13,
       "line": 1,
     },
     "start": Object {
@@ -9295,7 +9158,7 @@ exports[`test/index.js TAP > :root > *.workspace 1`] = `
 }
 `
 
-exports[`test/index.js TAP > :root > *:has(* > #bar@1.4.0) 1`] = `
+exports[`test/index.js TAP > :root > *:has(* > #bar) 1`] = `
 &ref_4 Root {
   "_error": Function (message, errorOptions),
   "indexes": Object {},
@@ -9429,7 +9292,7 @@ exports[`test/index.js TAP > :root > *:has(* > #bar@1.4.0) 1`] = `
                     "parent": <*ref_2>,
                     "source": Object {
                       "end": Object {
-                        "column": 24,
+                        "column": 22,
                         "line": 1,
                       },
                       "start": Object {
@@ -9443,13 +9306,13 @@ exports[`test/index.js TAP > :root > *:has(* > #bar@1.4.0) 1`] = `
                       "before": "",
                     },
                     "type": "id",
-                    "value": "bar@1.4.0",
+                    "value": "bar",
                   },
                 ],
                 "parent": <*ref_3>,
                 "source": Object {
                   "end": Object {
-                    "column": 29,
+                    "column": 23,
                     "line": 1,
                   },
                   "start": Object {
@@ -9474,7 +9337,7 @@ exports[`test/index.js TAP > :root > *:has(* > #bar@1.4.0) 1`] = `
           "parent": <*ref_1>,
           "source": Object {
             "end": Object {
-              "column": 29,
+              "column": 23,
               "line": 1,
             },
             "start": Object {
@@ -9494,7 +9357,7 @@ exports[`test/index.js TAP > :root > *:has(* > #bar@1.4.0) 1`] = `
       "parent": <*ref_4>,
       "source": Object {
         "end": Object {
-          "column": 29,
+          "column": 23,
           "line": 1,
         },
         "start": Object {
@@ -9511,7 +9374,7 @@ exports[`test/index.js TAP > :root > *:has(* > #bar@1.4.0) 1`] = `
   ],
   "source": Object {
     "end": Object {
-      "column": 29,
+      "column": 23,
       "line": 1,
     },
     "start": Object {

--- a/test/index.js
+++ b/test/index.js
@@ -48,9 +48,9 @@ const checks = [
   [':not(:not(:link))'],
 
   // has pseudo-class
-  [':root > *:has(* > #bar@1.4.0)'],
-  ['*:has(* > #bar@1.4.0)'],
-  ['*:has(> #bar@1.4.0)'],
+  [':root > *:has(* > #bar)'],
+  ['*:has(* > #bar)'],
+  ['*:has(> #bar)'],
   ['.workspace:has(> * > #lorem)'],
   ['.workspace:has(* #lorem, ~ #b)'],
 
@@ -142,8 +142,6 @@ const checks = [
 
   // id selector
   ['#bar'],
-  ['#bar@2.0.0'],
-  ['#@npmcli/abbrev@2.0.0-beta.45'],
   ['#bar:semver(2.0)'],
   ['#bar:semver(2)'],
   ['#bar:semver(^2.0.0)'],
@@ -172,7 +170,7 @@ const checks = [
   [':root #bar:semver(1) > *'],
   [':root #bar:semver(1) ~ *'],
   ['#bar:semver(2), #foo'],
-  ['#a, #bar:semver(2), #foo@2.2.2'],
+  ['#a, #bar:semver(2), #foo'],
 ]
 
 for (const [query] of checks) {


### PR DESCRIPTION
BREAKING CHANGE: You can no longer select a version along with an name
selector (i.e. `#npm@9.0.0`).  Use `#name:semver()` instead.

semver and dependency type selectors collide in syntax, so we are no
longer trying to parse a version with a name selector.

An example can show why this is impossible to parse:
`@npmcli/test-package@1.2.3-pre.prod`.

There is no way to know if `.prod` is supposed to be the `.prod`
dependency type selector or if it is part of the pre-release section of
the version.  So now you must use one of these two syntaxes depending on
what the version actually is:

If `.prod` is part of the version:
`#@npmcli/test-package:semver(1.2.3-pre.prod)`

If `.prod` is a dependency type selector:
`#@npmcli/test-package:semver(1.2.3-pre).prod`